### PR TITLE
Generate agent autoregistration key

### DIFF
--- a/build
+++ b/build
@@ -33,11 +33,15 @@ task :ensure_clean_config do
   config = Nokogiri::XML(File.read('output/data/config/cruise-config.xml'))
 
   allowed_attributes_at_server_level = ['agentAutoRegisterKey', 'artifactsdir', 'commandRepositoryLocation']
-  extra_attributes_at_server_level = config.at_xpath('/cruise/server').attributes.keys - allowed_attributes_at_server_level
+  attributes_at_server_level = config.at_xpath('/cruise/server').attributes
+  extra_attributes_at_server_level = attributes_at_server_level.keys - allowed_attributes_at_server_level
 
   raise "Found extra attributes at <server/> level in template/data/config/cruise.config.xml - Allowed attributes are: #{allowed_attributes_at_server_level}. Extra attributes are: #{extra_attributes_at_server_level}" unless extra_attributes_at_server_level.empty?
 
   raise "Found <agents/> tag in template/data/config/cruise-config.xml. That is not allowed." unless config.at_xpath('/cruise/agents').nil?
+
+  autoregister_key_value = attributes_at_server_level['agentAutoRegisterKey'].value
+  raise "Agent auto register key's value in config should only be: 'agent-autoregister-key'. It is: #{autoregister_key_value}" unless autoregister_key_value == 'agent-autoregister-key'
 end
 
 
@@ -50,7 +54,7 @@ end
 
 
 desc 'Package up the config repository files into a bare repository'
-task 'package_config_repo_files_into_bare_repo' do
+task :package_config_repo_files_into_bare_repo do
   config_repo_files_dir = File.join Dir.pwd, 'config-repo'
   repo_dir              = File.join Dir.pwd, 'output/repositories'
   repo_name             = 'repo1.git'

--- a/template/scripts/agent/use_shared_auto_registration_key.sh
+++ b/template/scripts/agent/use_shared_auto_registration_key.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+while [ ! -f '/shared/autoregister.key' ]; do
+  echo 'Waiting for server to decide agent auto registration key ...'
+  sleep 3
+done
+
+uuid=$(cat '/shared/autoregister.key')
+
+sed -i -e "s/agent.auto.register.key=.*/agent.auto.register.key=${uuid}/" '/go/config/autoregister.properties'

--- a/template/scripts/server/setup_agent_auto_registration_key.sh
+++ b/template/scripts/server/setup_agent_auto_registration_key.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+if ! grep -q 'agentAutoRegisterKey="agent-autoregister-key"' /go-working-dir/config/cruise-config.xml; then
+  echo 'Agent auto registration key is already set up.'
+  exit 0
+fi
+
+uuid=$(python -c 'import uuid; print str(uuid.uuid4())')
+
+sed -i -e "s/agentAutoRegisterKey=\"agent-autoregister-key\"/agentAutoRegisterKey=\"${uuid}\"/" /go-working-dir/config/cruise-config.xml
+
+echo -n "${uuid}" >/shared/autoregister.key


### PR DESCRIPTION
Remove the need for a checked-in + known key.

FYI: @ketan - I decided to keep the generated key in the shared location (and not delete it after the agent has seen it), since this docker-compose.yml can also be used with docker stack, with agent replicas.